### PR TITLE
ECC Signature Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/index.js
+++ b/index.js
@@ -170,9 +170,9 @@ PaymentProtocol.prototype.verifyPaymentRequest = function verifyPaymentRequest(r
   }
 
   let valid = secp256k1.verify(
-    new Buffer(hash, 'hex'),
-    new Buffer(signature, 'hex'),
-    new Buffer(keyData.publicKey, 'hex')
+    Buffer.from(hash, 'hex'),
+    Buffer.from(signature, 'hex'),
+    Buffer.from(keyData.publicKey, 'hex')
   );
 
   if (!valid) {

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const util = require('util');
 //Modules
 const _ = require('lodash');
 const request = require('request');
+const secp256k1 = require('secp256k1');
 
 function PaymentProtocol(options) {
   this.options = _.merge({
@@ -24,7 +25,7 @@ PaymentProtocol.prototype.getRawPaymentRequest = function getRawPaymentRequest(p
   let paymentUrlObject = url.parse(paymentUrl);
 
   //Detect 'bitcoin:' urls and extract payment-protocol section
-  if (paymentUrlObject.protocol !== 'http' && paymentUrlObject.protocol !== 'https') {
+  if (paymentUrlObject.protocol !== 'http:' && paymentUrlObject.protocol !== 'https:') {
     let uriQuery = query.decode(paymentUrlObject.query);
     if (!uriQuery.r) {
       return callback(new Error('Invalid payment protocol url'));
@@ -49,7 +50,7 @@ PaymentProtocol.prototype.getRawPaymentRequest = function getRawPaymentRequest(p
       return callback(new Error(response.body.toString()));
     }
 
-    return callback(null, {rawBody: response.body, headers: response.headers});
+    return callback(null, {rawBody: response.body, headers: response.headers, requestUrl: paymentUrl});
   });
 };
 
@@ -93,6 +94,9 @@ PaymentProtocol.prototype.parsePaymentRequest = function parsePaymentRequest(raw
     return callback(new Error(`Response body hash does not match digest header. Actual: ${hash} Expected: ${digest}`));
   }
 
+  paymentRequest.hash = hash;
+  paymentRequest.headers = headers;
+
   return callback(null, paymentRequest);
 };
 
@@ -102,6 +106,91 @@ PaymentProtocol.prototype.parsePaymentRequest = function parsePaymentRequest(raw
  * @param headers {object} Headers sent by the payment protocol server
  */
 PaymentProtocol.prototype.parsePaymentRequestAsync = util.promisify(PaymentProtocol.prototype.parsePaymentRequest);
+
+/**
+ * Verifies the signature of a given payment request is both valid and from a trusted key
+ * @param requestUrl {String} The url used to fetch this payment request
+ * @param paymentRequest {Object} The payment request object returned by parsePaymentRequest
+ * @param trustedKeys {Object} An object containing all keys trusted by this client
+ * @param callback {function} If no error is returned callback will contain the owner of the key which signed this request (ie BitPay Inc.)
+ */
+PaymentProtocol.prototype.verifyPaymentRequest = function verifyPaymentRequest(requestUrl, paymentRequest, trustedKeys, callback) {
+  let hash = paymentRequest.headers.digest.split('=')[1];
+  let signature = paymentRequest.headers.signature;
+  let signatureType = paymentRequest.headers['x-signature-type'];
+  let identity = paymentRequest.headers['x-identity'];
+  let host;
+
+  if (!requestUrl) {
+    return callback(new Error('You must provide the original payment request url'));
+  }
+  if (!trustedKeys) {
+    return callback(new Error('You must provide a set of trusted keys'))
+  }
+
+  try {
+    host = url.parse(requestUrl).hostname;
+  }
+  catch(e) {}
+
+  if (!host) {
+    return callback(new Error('Invalid requestUrl'));
+  }
+  if (!signatureType) {
+    return callback(new Error('Response missing x-signature-type header'));
+  }
+  if (typeof signatureType !== 'string') {
+    return callback(new Error('Invalid x-signature-type header'));
+  }
+  if (signatureType !== 'ecc') {
+    return callback(new Error(`Unknown signature type ${signatureType}`))
+  }
+  if (!signature) {
+    return callback(new Error('Response missing signature header'));
+  }
+  if (typeof signature !== 'string') {
+    return callback(new Error('Invalid signature header'));
+  }
+  if (!identity) {
+    return callback(new Error('Response missing x-identity header'));
+  }
+  if (typeof identity !== 'string') {
+    return callback(new Error('Invalid identity header'));
+  }
+
+  if (!trustedKeys[identity]) {
+    return callback(new Error(`Response signed by unknown key (${identity}), unable to validate`));
+  }
+
+  let keyData = trustedKeys[identity];
+  if (keyData.domains.indexOf(host) === -1) {
+    return callback(new Error(`The key on the response (${identity}) is not trusted for domain ${host}`));
+  } else if (!keyData.networks.includes(paymentRequest.network)) {
+    return callback(new Error(`The key on the response is not trusted for transactions on the '${paymentRequest.network}' network`));
+  }
+
+  let valid = secp256k1.verify(
+    new Buffer(hash, 'hex'),
+    new Buffer(signature, 'hex'),
+    new Buffer(keyData.publicKey, 'hex')
+  );
+
+  if (!valid) {
+    return callback(new Error('Response signature invalid'));
+  }
+
+  return callback(null, keyData.owner);
+};
+
+/**
+ * Verifies the signature of a given payment request is both valid and from a trusted key
+ * @param requestUrl {String} The url used to fetch this payment request
+ * @param paymentRequest {Object} The payment request object returned by parsePaymentRequest
+ * @param trustedKeys {Object} An object containing all keys trusted by this client
+ * @returns {String} The owner of the key which signed this request (ie BitPay Inc.) which should be displayed to the user
+ */
+PaymentProtocol.prototype.parsePaymentRequestAsync = util.promisify(PaymentProtocol.prototype.parsePaymentRequest);
+
 
 /**
  * Sends a given payment to the server for validation

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ This is the first version of the JSON payment protocol interface. If you have qu
 We support both callbacks and promises. For promises just add Async to the end of the function name. Be careful to follow the notes about when to broadcast your payment. **Broadcasting a payment before getting a success notification back from the server in most cases will lead to a failed payment for the sender.** The sender will bear the cost of paying transaction fees yet again to get their money back.
 
 #### Callbacks
-```
+```js
 const JsonPaymentProtocol = require('json-payment-protocol');
 const paymentProtocol = new JsonPaymentProtocol();
 
@@ -46,7 +46,7 @@ paymentProtocol.getRawPaymentRequest(requestUrl, function (err, response) {
 ```
 
 #### Promises
-```
+```js
 const JsonPaymentProtocol = require('json-payment-protocol');
 const paymentProtocol = new JsonPaymentProtocol();
 
@@ -80,7 +80,7 @@ paymentProtocol
 
 Options passed to `new JsonPaymentProtocol()` are passed to request, so if you need to use a proxy or set any other request.js flags you can do so by including them when instantiating your instance. For example:
 
-```
+```js
 new JsonPaymentProtocol({
   proxy: 'socks://mySocksProxy.local'
 })

--- a/specification.md
+++ b/specification.md
@@ -10,12 +10,12 @@ Revision 0.6
 4. (Server) Verifies invoice exists and is still accepting payments, responds with payment request
 5. (Client) Validates payment request hash
 6. (Client) Validates payment request signature
-6. (Client) Generates a payment to match conditions on payment request
-7. (Client) Submits proposed signed transaction to server
-8. (Server) Validates invoice exists and is still accepting payments
-9. (Server) Validates payment matches address, amount, and currency of invoice and has a reasonable transaction fee.
-10. (Server) Broadcasts payment to network and notifies client payment was accepted.
-11. (Client) If payment is accepted by server, wallet broadcasts payment
+7. (Client) Generates a payment to match conditions on payment request
+8. (Client) Submits proposed signed transaction to server
+9. (Server) Validates invoice exists and is still accepting payments
+10. (Server) Validates payment matches address, amount, and currency of invoice and has a reasonable transaction fee.
+11. (Server) Broadcasts payment to network and notifies client payment was accepted.
+12. (Client) If payment is accepted by server, wallet broadcasts payment
 
 In general, the payment should not be broadcast by the client. If at any time the payment is rejected by the server **your client must not broadcast the payment**.
 Broadcasting a payment before getting a success notification back from the server will in most cases lead to a failed payment for the sender. The sender will bear the cost of paying transaction fees yet again to get their money back.

--- a/specification.md
+++ b/specification.md
@@ -1,6 +1,6 @@
 # JSON Payment Protocol Specification
 
-Revision 0.5
+Revision 0.6
 
 ## Application Logic
 
@@ -9,6 +9,7 @@ Revision 0.5
 3. (Client) Fetches payment information from server
 4. (Server) Verifies invoice exists and is still accepting payments, responds with payment request
 5. (Client) Validates payment request hash
+6. (Client) Validates payment request signature
 6. (Client) Generates a payment to match conditions on payment request
 7. (Client) Submits proposed signed transaction to server
 8. (Server) Validates invoice exists and is still accepting payments
@@ -28,9 +29,12 @@ A GET request should be made to the payment protocol url.
 The response will be a JSON format payload quite similar to the BIP70 format.
 
 #### Headers
-On a successful request, the response will contain one header of note.
+On a successful request, the response will contain a few headers of note.
 
 * `digest` - A SHA256 hash of the JSON response string, should be verified by the client before proceeding
+* `x-identity` - An identifier to represent which public key should be used to verify the signature. For example for BitPay's ECC keys we will include the public key hash in this header. Implementations should **NOT** include the public key here directly.
+* `x-signature-type` The signature format used to sign the payload. For the foreseeable future BitPay will always use `ECC`. However, we wanted to grant some flexibility to the specification.
+* `x-signature` - A cryptographic signature of the SHA256 hash of the payload. This is to prove that the payment request was not tampered with before being received by the wallet.
 
 #### Body
 * `network` - Which network is this request for (main / test / regtest)
@@ -126,6 +130,143 @@ curl -v -H 'Content-Type: application/payment' -d '{"currency": "BTC", "transact
 {"payment":{"transactions":["02000000012319227d3995427b05429df7ea30b87cb62f986ba3003311a2cf2177fb5b0ae8000000004847304402205bd75d6b654a70dcc8f548b630c39aec1d2c1de6900b5376ef607efc705f65b002202dd1036f091d4d6047e2f5bcd230ec8bcd5ad2f0785908d78f08a52b8850559f01ffffffff02b09a0000000000001976a9140b2a833c4183c51b86f5dcbb2eeeaca2dfb44bae88acdccb042a010000001976a914f0fd63e5880cbed2fa856e1f4174fc875eeccc5a88ac00000000"]},"memo":"Transaction received by BitPay. Invoice will be marked as paid if the transaction is confirmed."}%
 ```
 
+## Signatures
+
+Many wallet developers have voiced complaints about needing to use x509 PKI in order to verify payments, so here we're attempting to provide an answer. We will ensure payload integrity for all payment requests via an ECDSA signature.
+For those unaware, this is the exact same method all bitcoin transactions are authenticated. This should make it much easier for wallets to implement since they already have code to do this. We will distribute public keys which can be used to verify the signatures.
+How you choose to store the keys for verifying providers is up to you as a wallet developer, but we do make some recommendations below.
+
+Since there will potentially be multiple providers using this system each with multiple keys, the payment request will include an `x-identity` header will contain some unique identifier to indicate which public key was used to sign the payload. In the case of ECSDA signatures we
+will provide the RIPEMD160+SHA256 hash of the public key in this header (same format as a bitcoin address). We have chosen not to send the public key itself here as that would lead to the possibility of wallet developers naively trusting whatever public key was sent via the header
+and verifying against that. By only sending a hash of the public key the wallet developer is required to follow best practices of retrieving the public keys from a trusted source.
+
+### Key Distribution
+The JSON payment protocol provider will make keys available via the route:
+* <paymentRequestDomain>/signingKeys/paymentProtocol.json
+
+This route will serve a JSON payload which conforms to the format:
+
+```
+{
+  "owner": "Company name that may be displayed to the user",
+  "expirationDate": "ISO format date when these keys expire",
+  "validDomains": [
+    "myDomain.com",
+    "payments.myDomain.com"
+  ],
+  "publicKeys": [
+    "hexadecimalEncodedPublicKeyHere"
+  ]
+}
+```
+
+An example of this fully completed:
+```
+{
+  "owner": "BitPay, Inc.",
+  "expirationDate": "2018-06-01T00:00:00.000Z",
+  "validDomains": [
+    "test.bitpay.com"
+  ],
+  "publicKeys": [
+    "03361b5c0d5d2fec5c9313ab79b82266c576254697546a4868d860423557f3a52f"
+  ]
+}
+```
+
+
+### Key Signature Distribution
+The JSON payment protocol provider will distribute PGP signatures of the distributed keys available via:
+* <paymentRequestDomain>/signatures/<sha256HashOfKeyPayload>.json
+
+The SHA256 should be performed on the raw body of the keys sent down by the server.
+
+This ensures that even if the provider's SSL certificate is compromised that the attacker cannot forge payment requests.
+
+This route will server a JSON payload which conforms to the format:
+```
+{
+  "keyHash": "SHA256 hash of key payload",
+  "signatures": [
+    {
+      "created": "ISO Date when this signature was created",
+      "identifier": "GPG fingerprint",
+      "signature": "hexadecimal encoded detached GPG signature of key payload"
+    }
+  ]
+}
+```
+
+An example of this fully completed:
+```
+{
+  "keyHash": "622c5dc05501b848221a9e0b2e9a84c0869cdb7604d785a0486fe817c9c34fe1",
+  "signatures": [
+    {
+      "created": "2018-03-07T01:46:39.310Z",
+      "identifier": "3c936ad8b8fa8de3290bc45cae7eefda5240818d",
+      "signature": "2d2d2d2d2d424547494e20504750205349474e41545552452d2d2d2d2d0a436f6d6d656e743a20475047546f6f6c73202d2068747470733a2f2f677067746f6f6c732e6f72670a0a6951497a424141424367416446694545504a4e71324c6a366a654d7043385263726e3776326c4a4167593046416c714d62574d4143676b51726e3776326c4a410a6759306c73672f2b4e7839486577622b31527631347038676e7a4c563763536c6f4f422f5262586b694136426a76336a4166735a55623175484d6e617a3644370a736e6c306e47775233497966554c6d3254647536444e3043314e767549367374442f7362666473572b6c726a72666d6d6b377a2f36726c593169684a6d5061330a6758344f4d63577061352f4e56636a436f432b546b51434b4d77684237424b7030344a363679326f78382f583736574c6d685544366b6b6155565979656637520a79566666784c6d766747627a476d7433445958316a59524a766d4e6b6f5749466f30557254576d7a55457961505538457950386d415075347a413749453834650a546f57634e38714b576564797879396e615147493679376a5149445a72454a30315a56785371326b6352506e464d694432772f6c69704b6b504a4e577556764e0a3834644f4372324859302b584769726c74744c673167363077314a5333455354714938374a786766716f53695257666c4d4f736667712f6e302b7243337057620a535030397245457a307069705376374d5a723944436142435261544142333156567a6f4c48536e67452b4a4f5264615a4a2f7274796f315366634c5a75314d320a4241735178786c7142306449617174534830386b50496e6a5a746776346358766142556443507178774d6f444c664d643152324330705033337453465533534b0a4e6b786b4d326744536a41392b2b5754625267553543556c3642725942516a62415836773673715354775a42796e736e6270366c6d6f6f6c4b314341762b55500a7144444d4c6e6a696a62465861324476326833495650456246786178336a73303367557448496e4141552f4c4b4b4948583730664d644b45566c735845482b4b0a53395238446c4c355854467a38435175693175692f394f484f77523549672b5436532f5a3678504f51594d4d69562f6e6a48553d0a3d62357a450a2d2d2d2d2d454e4420504750205349474e41545552452d2d2d2d2d"
+    },
+    {
+      "created": "2018-03-07T01:46:39.310Z",
+      "identifier": "3c936ad8b8fa8de3290bc45cae7eefda5240818d",
+      "signature": "2d2d2d2d2d424547494e20504750205349474e41545552452d2d2d2d2d0a436f6d6d656e743a20475047546f6f6c73202d2068747470733a2f2f677067746f6f6c732e6f72670a0a6951497a424141424367416446694545504a4e71324c6a366a654d7043385263726e3776326c4a4167593046416c714d62574d4143676b51726e3776326c4a410a6759306c73672f2b4e7839486577622b31527631347038676e7a4c563763536c6f4f422f5262586b694136426a76336a4166735a55623175484d6e617a3644370a736e6c306e47775233497966554c6d3254647536444e3043314e767549367374442f7362666473572b6c726a72666d6d6b377a2f36726c593169684a6d5061330a6758344f4d63577061352f4e56636a436f432b546b51434b4d77684237424b7030344a363679326f78382f583736574c6d685544366b6b6155565979656637520a79566666784c6d766747627a476d7433445958316a59524a766d4e6b6f5749466f30557254576d7a55457961505538457950386d415075347a413749453834650a546f57634e38714b576564797879396e615147493679376a5149445a72454a30315a56785371326b6352506e464d694432772f6c69704b6b504a4e577556764e0a3834644f4372324859302b584769726c74744c673167363077314a5333455354714938374a786766716f53695257666c4d4f736667712f6e302b7243337057620a535030397245457a307069705376374d5a723944436142435261544142333156567a6f4c48536e67452b4a4f5264615a4a2f7274796f315366634c5a75314d320a4241735178786c7142306449617174534830386b50496e6a5a746776346358766142556443507178774d6f444c664d643152324330705033337453465533534b0a4e6b786b4d326744536a41392b2b5754625267553543556c3642725942516a62415836773673715354775a42796e736e6270366c6d6f6f6c4b314341762b55500a7144444d4c6e6a696a62465861324476326833495650456246786178336a73303367557448496e4141552f4c4b4b4948583730664d644b45566c735845482b4b0a53395238446c4c355854467a38435175693175692f394f484f77523549672b5436532f5a3678504f51594d4d69562f6e6a48553d0a3d62357a450a2d2d2d2d2d454e4420504750205349474e41545552452d2d2d2d2d"
+    }
+  ]
+}
+```
+Please note that these example signatures may not match the example key payload, don't use them for testing
+
+
+### PGP Key Distribution
+It is ultimately up to the JSON payment protocol provider as to how they will distribute the PGP public keys used to sign their payment protocol signing keys. We recommend using multiple distribution paths, at least one of which should not be on the same domain as the payment requests.
+
+### BitPay Specific Signature Details
+
+#### Signing
+For the foreseeable future all of BitPay's payment requests will be signed via ECDSA using the SECP 256 k1 curve (the same as used in Bitcoin itself). This is to allow very simple compatibility with wallets, as every wallet should already be fully able to verify ECC signatures of bitcoin transactions.
+
+#### PGP Key Distribution
+BitPay will make its PGP keys available via the following resources:
+
+* https://github.com/bitpay/pgp-keys
+* https://bitpay.com/pgp-keys (or in JSON format https://bitpay.com/pgp-keys.json)
+
+Please take time to verify the keys in both places.
+
+#### Key-storing suggestions
+Some wallets may not be sure about the best way to store the ECC public keys for JSON payment protocol providers. There are likely to be two or three common approaches. Regardless of your approach, we recommend keeping in mind that keys can be compromised and therefore may require being changed
+relatively quickly. It also may also be reasonable for advanced users to want to add their own keys for development purposes, but keep in mind that less advanced users may be tricked into doing this if appropriate warnings are not provided. Remember you will always need to store the domains and the
+owner for each key so that you can prevent a key from being used on the wrong domain, and so that the user knows who owns the key.
+
+##### Approach one
+The simplest approach would be to simply verify all the keys we've distributed locally and then directly bake them into your wallet code. This has the advantage of being quite secure, however the direct disadvantage is that if a key is revoked or the keys change for any reason your user is stuck until
+you release an update.
+
+##### Pros:
+* Wallet signature logic is very simple
+
+##### Cons:
+* Key revocation may result in needing to push emergency updates to your wallet (remember Apple App store can be slow to accept updates)
+
+##### Approach two
+The second approach would be to generate your own ECC key pair and hard code it's public key into your app. You would then verify our (and others) keys in your development environment and if valid publish them to your own API, signed by your own ECC key. Wallets would then verify against the keys from
+your API each time they wanted to verify a payment request. This allows for relatively quick changing of which keys are considered valid by simply updating your own API.
+
+##### Pros:
+* Usable across multiple providers
+* Pretty reasonable key update time
+
+##### Cons:
+* Still have cases where keys could be out of date for hours (or days for some wallets)
+
+##### Approach three
+The third approach is to bake our PGP keys into your wallet. On first boot the wallet would retrieve our signing keys and their signatures and verify them. Once verified the app would store the SHA256 hash of the keys. The wallet could then periodically retrieve our key list and only re-validate them
+if the SHA256 hash is different than the one previously stored.
+##### Pros:
+* Always up to date
+##### Cons:
+* Potentially need a specific implementation per-provider
 
 ## Errors
 

--- a/specification.md
+++ b/specification.md
@@ -29,7 +29,7 @@ A GET request should be made to the payment protocol url.
 The response will be a JSON format payload quite similar to the BIP70 format.
 
 #### Headers
-On a successful request, the response will contain a few headers of note.
+On a successful request, the response will contain the following headers.
 
 * `digest` - A SHA256 hash of the JSON response string, should be verified by the client before proceeding
 * `x-identity` - An identifier to represent which public key should be used to verify the signature. For example for BitPay's ECC keys we will include the public key hash in this header. Implementations should **NOT** include the public key here directly.

--- a/specification.md
+++ b/specification.md
@@ -136,7 +136,7 @@ Many wallet developers have voiced complaints about needing to use x509 PKI in o
 For those unaware, this is the exact same method all bitcoin transactions are authenticated. This should make it much easier for wallets to implement since they already have code to do this. We will distribute public keys which can be used to verify the signatures.
 How you choose to store the keys for verifying providers is up to you as a wallet developer, but we do make some recommendations below.
 
-Since there will potentially be multiple providers using this system each with multiple keys, the payment request will include an `x-identity` header will contain some unique identifier to indicate which public key was used to sign the payload. In the case of ECSDA signatures we
+Since there will potentially be multiple providers using this system each with multiple keys, the payment request will include an `x-identity` header will contain a unique identifier to indicate which public key was used to sign the payload. In the case of ECSDA signatures we
 will provide the RIPEMD160+SHA256 hash of the public key in this header (same format as a bitcoin address). We have chosen not to send the public key itself here as that would lead to the possibility of wallet developers naively trusting whatever public key was sent via the header
 and verifying against that. By only sending a hash of the public key the wallet developer is required to follow best practices of retrieving the public keys from a trusted source.
 


### PR DESCRIPTION
This adds support for verifying ECC signed payment requests, an alternative to CA based payment protocol in BIP70.

fixes #6 