### PR TITLE
Fix docs and add key example

### DIFF
--- a/examples/fetchEccKeysAndVerify.js
+++ b/examples/fetchEccKeysAndVerify.js
@@ -1,0 +1,199 @@
+const crypto = require('crypto');
+
+const bs58 = require('bs58');
+const kbpgp = require('kbpgp');
+const request = require('request-promise');
+
+let bitpayPgpKeys = {};
+let githubPgpKeys = {};
+let importedPgpKeys = {};
+let signatureCount = 0;
+
+let eccPayload;
+let parsedEccPayload;
+let eccKeysHash;
+
+let keyRequests = [];
+
+keyRequests.push((() => {
+  console.log('Fetching keys from github.com/bitpay/pgp-keys...');
+  return request({
+    method: 'GET',
+    url: 'https://api.github.com/repos/bitpay/pgp-keys/contents/keys',
+    headers: {
+      'user-agent': 'BitPay Key-Check Utility'
+    },
+    json: true
+  }).then((pgpKeyFiles) => {
+    let fileDataPromises = [];
+    pgpKeyFiles.forEach((file) => {
+      fileDataPromises.push((() => {
+        return request({
+          method: 'GET',
+          url: file.download_url,
+          headers: {
+            'user-agent': 'BitPay Key-Check Utility'
+          }
+        }).then((body) => {
+          let hash = crypto.createHash('sha256').update(body).digest('hex');
+          githubPgpKeys[hash] = body;
+          return Promise.resolve();
+        });
+      })());
+    });
+    return Promise.all(fileDataPromises);
+  });
+})());
+
+keyRequests.push((() => {
+  console.log('Fetching keys from bitpay.com/pgp-keys...');
+  return request({
+    method: 'GET',
+    url: 'https://bitpay.com/pgp-keys.json',
+    headers: {
+      'user-agent': 'BitPay Key-Check Utility'
+    },
+    json: true
+  }).then((body) => {
+    body.pgpKeys.forEach(function(key) {
+      let hash = crypto.createHash('sha256').update(key.publicKey).digest('hex');
+      bitpayPgpKeys[hash] = key.publicKey;
+    });
+    return Promise.resolve();
+  });
+})());
+
+Promise.all(keyRequests).then(() => {
+  if (Object.keys(githubPgpKeys).length !== Object.keys(bitpayPgpKeys).length) {
+    console.log('Warning: Different number of keys returned by key lists');
+  }
+
+  let bitpayOnlyKeys = Object.keys(bitpayPgpKeys).filter((keyHash) => {
+    return !githubPgpKeys[keyHash];
+  });
+
+  let githubOnlyKeys = Object.keys(githubPgpKeys).filter((keyHash) => {
+    return !bitpayPgpKeys[keyHash];
+  });
+
+  if (bitpayOnlyKeys.length) {
+    console.log('BitPay returned some keys which are not present in github');
+    Object.keys(bitpayOnlyKeys).forEach((keyHash) => {
+      console.log(`Hash ${keyHash} Key: ${bitpayOnlyKeys[keyHash]}`);
+    });
+  }
+
+  if (githubOnlyKeys.length) {
+    console.log('GitHub returned some keys which are not present in BitPay');
+    Object.keys(githubOnlyKeys).forEach((keyHash) => {
+      console.log(`Hash ${keyHash} Key: ${githubOnlyKeys[keyHash]}`);
+    });
+  }
+
+  if (!githubOnlyKeys.length && !bitpayOnlyKeys.length) {
+    console.log(`Both sites returned ${Object.keys(githubPgpKeys).length} keys. Key lists from both are identical.`);
+    return Promise.resolve();
+  } else {
+    return Promise.reject('Aborting signature checks due to key mismatch');
+  }
+}).then(() => {
+  console.log('Importing PGP keys for later use...');
+  return Promise.all(Object.values(bitpayPgpKeys).map((pgpKeyString) => {
+    return new Promise((resolve, reject) => {
+      kbpgp.KeyManager.import_from_armored_pgp({armored: pgpKeyString}, (err, km) => {
+        if (err) {
+          return reject(err);
+        }
+        // console.log(km.pgp.key(km.pgp.primary).get_fingerprint().toString('hex'));
+        importedPgpKeys[km.pgp.key(km.pgp.primary).get_fingerprint().toString('hex')] = km;
+        return resolve();
+      });
+    });
+  }));
+}).then(() => {
+  console.log('Fetching current ECC keys from bitpay.com/signingKeys/paymentProtocol.json');
+  return request({
+    method: 'GET',
+    url: 'https://bitpay.com/signingKeys/paymentProtocol.json',
+    headers: {
+      'user-agent': 'BitPay Key-Check Utility'
+    }
+  }).then((rawEccPayload) => {
+    if (rawEccPayload.indexOf('rate limit') !== -1) {
+      return Promise.reject('Rate limited by BitPay');
+    }
+    eccPayload = rawEccPayload;
+    parsedEccPayload = JSON.parse(rawEccPayload);
+    if (new Date(parsedEccPayload.expirationDate) < Date.now()) {
+      return console.log('The currently published ECC keys are expired');
+    }
+    eccKeysHash = crypto.createHash('sha256').update(rawEccPayload).digest('hex');
+    return Promise.resolve();
+  });
+}).then(() => {
+  console.log(`Fetching signatures for ECC payload with hash ${eccKeysHash}`);
+  return request({
+    method: 'GET',
+    url: `https://bitpay.com/signatures/${eccKeysHash}.json`,
+    headers: {
+      'user-agent': 'BitPay Key-Check Utility'
+    },
+    json: true
+  }).then((signatureData) => {
+    console.log('Verifying each signature is valid and comes from the set of PGP keys retrieved earlier');
+    Promise.all(signatureData.signatures.map((signature) => {
+      return new Promise((resolve, reject) => {
+        let pgpKey = importedPgpKeys[signature.identifier];
+        if (!pgpKey) {
+          return reject(`PGP key ${signature.identifier} missing for signature`);
+        }
+        let armoredSignature = Buffer.from(signature.signature, 'hex').toString();
+
+        kbpgp.unbox({armored: armoredSignature, data: Buffer.from(eccPayload), keyfetch: pgpKey}, (err, result) => {
+          if (err) {
+            return reject(`Unable to verify signature from ${signature.identifier} ${err}`);
+          }
+          signatureCount++;
+          console.log(`Good signature from ${signature.identifier} (${pgpKey.get_userids()[0].get_username()})`);
+          return Promise.resolve();
+        });
+      });
+    }));
+  });
+}).then(() => {
+  if (signatureCount >= (Object.keys(bitpayPgpKeys).length / 2) ) {
+    console.log(`----\nThe following ECC key set has been verified against signatures from ${signatureCount} of the ${Object.keys(bitpayPgpKeys).length} published BitPay PGP keys.`);
+    console.log(eccPayload);
+
+    let keyMap = {};
+
+    console.log('----\nValid keymap for use in bitcoinRpc example:');
+
+    parsedEccPayload.publicKeys.forEach((pubkey) => {
+      // Here we are just generating the pubkey hash (btc address) of the
+      let a = crypto.createHash('sha256').update(pubkey, 'hex').digest();
+      let b = crypto.createHash('rmd160').update(a).digest('hex');
+      let c = '00' + b; // This is assuming livenet
+      let d = crypto.createHash('sha256').update(c, 'hex').digest();
+      let e = crypto.createHash('sha256').update(d).digest('hex');
+
+      let pubKeyHash = bs58.encode(Buffer.from(c + e.substr(0, 8), 'hex'));
+
+
+      keyMap[pubKeyHash] = {
+        owner: parsedEccPayload.owner,
+        networks: ['main'],
+        domains: parsedEccPayload.domains,
+        publicKey: pubkey
+      }
+    });
+
+    console.log(keyMap);
+  } else {
+    return Promise.reject(`Insufficient good signatures ${signatureCount} for a proper validity check`);
+  }
+}).catch((err) => {
+  console.log(`Error encountered ${err}`);
+});
+
+process.on('unhandledRejection', console.log);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "asn1": {
@@ -31,7 +31,7 @@
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "4.17.10"
       }
     },
     "asynckit": {
@@ -49,13 +49,22 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
       "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
     },
+    "base-x": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
+      "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "bindings": {
@@ -68,8 +77,20 @@
       "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
       "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "dev": true
+    },
+    "bn": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bn/-/bn-1.0.1.tgz",
+      "integrity": "sha1-oVOCXmsessLbdyYUmwR6B84KO7M=",
+      "dev": true
     },
     "bn.js": {
       "version": "4.11.8",
@@ -86,18 +107,33 @@
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "dev": true,
+      "requires": {
+        "base-x": "3.0.4"
       }
     },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+    },
+    "bzip-deflate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bzip-deflate/-/bzip-deflate-1.0.0.tgz",
+      "integrity": "sha1-sC2wB+83vrzCk4Skssb08PTHlsk=",
+      "dev": true
     },
     "caseless": {
       "version": "0.12.0",
@@ -109,8 +145,8 @@
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "co": {
@@ -123,7 +159,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "core-util-is": {
@@ -136,11 +172,11 @@
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "md5.js": "1.3.4",
+        "ripemd160": "2.0.2",
+        "sha.js": "2.4.11"
       }
     },
     "create-hmac": {
@@ -148,12 +184,12 @@
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.1.2",
+        "sha.js": "2.4.11"
       }
     },
     "dashdash": {
@@ -161,8 +197,14 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
+    },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -174,9 +216,9 @@
       "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
       "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
       "requires": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
+        "browserify-aes": "1.2.0",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7"
       }
     },
     "ecc-jsbn": {
@@ -185,7 +227,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "0.1.1"
       }
     },
     "elliptic": {
@@ -193,13 +235,13 @@
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "bn.js": "4.11.8",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.3",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "evp_bytestokey": {
@@ -207,8 +249,8 @@
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
+        "md5.js": "1.3.4",
+        "safe-buffer": "5.1.2"
       }
     },
     "extend": {
@@ -241,9 +283,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.18"
       }
     },
     "getpass": {
@@ -251,7 +293,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "har-schema": {
@@ -264,8 +306,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "hash-base": {
@@ -273,8 +315,8 @@
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "hash.js": {
@@ -282,8 +324,8 @@
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.0"
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "hmac-drbg": {
@@ -291,9 +333,9 @@
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
+        "hash.js": "1.1.3",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "http-signature": {
@@ -301,10 +343,31 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
       }
+    },
+    "iced-error": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/iced-error/-/iced-error-0.0.12.tgz",
+      "integrity": "sha1-4KhhRigXzwzpdLE/ymEtOg1dEL4=",
+      "dev": true
+    },
+    "iced-lock": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/iced-lock/-/iced-lock-1.1.0.tgz",
+      "integrity": "sha1-YRbvHKs6zW5rEIk7snumIv0/3nI=",
+      "dev": true,
+      "requires": {
+        "iced-runtime": "1.0.3"
+      }
+    },
+    "iced-runtime": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/iced-runtime/-/iced-runtime-1.0.3.tgz",
+      "integrity": "sha1-LU9PuZmreqVDCxk8d6f85BGDGc4=",
+      "dev": true
     },
     "inherits": {
       "version": "2.0.3",
@@ -353,6 +416,63 @@
         "verror": "1.10.0"
       }
     },
+    "kbpgp": {
+      "version": "2.0.77",
+      "resolved": "https://registry.npmjs.org/kbpgp/-/kbpgp-2.0.77.tgz",
+      "integrity": "sha1-bp0vV5hb6VlsXqbJ5aODM/MasZk=",
+      "dev": true,
+      "requires": {
+        "bn": "1.0.1",
+        "bzip-deflate": "1.0.0",
+        "deep-equal": "1.0.1",
+        "iced-error": "0.0.12",
+        "iced-lock": "1.1.0",
+        "iced-runtime": "1.0.3",
+        "keybase-ecurve": "1.0.0",
+        "keybase-nacl": "1.0.10",
+        "minimist": "1.2.0",
+        "pgp-utils": "0.0.34",
+        "purepack": "1.0.4",
+        "triplesec": "3.0.26",
+        "tweetnacl": "0.13.3"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+          "integrity": "sha1-1ii1bzvMPVrnS6nUwacE3vWrS1Y=",
+          "dev": true
+        }
+      }
+    },
+    "keybase-ecurve": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/keybase-ecurve/-/keybase-ecurve-1.0.0.tgz",
+      "integrity": "sha1-xrxyrdpGA/0xhP7n6ZaU7Y/WmtI=",
+      "dev": true,
+      "requires": {
+        "bn": "1.0.1"
+      }
+    },
+    "keybase-nacl": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/keybase-nacl/-/keybase-nacl-1.0.10.tgz",
+      "integrity": "sha1-OGWDHpSBUWSI33y9mJRn6VDYeos=",
+      "dev": true,
+      "requires": {
+        "iced-runtime": "1.0.3",
+        "tweetnacl": "0.13.3",
+        "uint64be": "1.0.1"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.13.3.tgz",
+          "integrity": "sha1-1ii1bzvMPVrnS6nUwacE3vWrS1Y=",
+          "dev": true
+        }
+      }
+    },
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
@@ -363,8 +483,8 @@
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       }
     },
     "mime-db": {
@@ -377,7 +497,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "1.33.0"
       }
     },
     "minimalistic-assert": {
@@ -389,6 +509,21 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
       "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "more-entropy": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/more-entropy/-/more-entropy-0.0.7.tgz",
+      "integrity": "sha1-Z7/G96hvJvvDeqyD/UbYjGHRCbU=",
+      "dev": true,
+      "requires": {
+        "iced-runtime": "1.0.3"
+      }
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -411,19 +546,41 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "pgp-utils": {
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/pgp-utils/-/pgp-utils-0.0.34.tgz",
+      "integrity": "sha1-2E9J98GTteC5QV9cxcKmle15DCM=",
+      "dev": true,
+      "requires": {
+        "iced-error": "0.0.12",
+        "iced-runtime": "1.0.3"
+      }
+    },
+    "progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "dev": true
+    },
     "promptly": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/promptly/-/promptly-2.2.0.tgz",
       "integrity": "sha1-KhP6BjaIoqWYOxYf/wEIoH0m/HQ=",
       "dev": true,
       "requires": {
-        "read": "^1.0.4"
+        "read": "1.0.7"
       }
     },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "purepack": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/purepack/-/purepack-1.0.4.tgz",
+      "integrity": "sha1-CGKC/ZOShfWGZLqam7oxzbFlzNI=",
+      "dev": true
     },
     "qs": {
       "version": "6.5.2",
@@ -436,7 +593,7 @@
       "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
       "dev": true,
       "requires": {
-        "mute-stream": "~0.0.4"
+        "mute-stream": "0.0.7"
       }
     },
     "request": {
@@ -444,26 +601,47 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
       "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.2.1"
+      }
+    },
+    "request-promise": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
+      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.4"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.10"
       }
     },
     "ripemd160": {
@@ -471,8 +649,8 @@
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.0.4",
+        "inherits": "2.0.3"
       }
     },
     "safe-buffer": {
@@ -490,14 +668,14 @@
       "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
       "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
       "requires": {
-        "bindings": "^1.2.1",
-        "bip66": "^1.1.3",
-        "bn.js": "^4.11.3",
-        "create-hash": "^1.1.2",
-        "drbg.js": "^1.0.1",
-        "elliptic": "^6.2.3",
-        "nan": "^2.2.1",
-        "safe-buffer": "^5.1.0"
+        "bindings": "1.3.0",
+        "bip66": "1.1.5",
+        "bn.js": "4.11.8",
+        "create-hash": "1.2.0",
+        "drbg.js": "1.0.1",
+        "elliptic": "6.4.0",
+        "nan": "2.10.0",
+        "safe-buffer": "5.1.2"
       }
     },
     "sha.js": {
@@ -505,8 +683,8 @@
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.2"
       }
     },
     "sshpk": {
@@ -514,23 +692,42 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
     },
     "tough-cookie": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
+      }
+    },
+    "triplesec": {
+      "version": "3.0.26",
+      "resolved": "https://registry.npmjs.org/triplesec/-/triplesec-3.0.26.tgz",
+      "integrity": "sha1-3/K7R1ikIzcuc5o5fYmR8Fl9CsE=",
+      "dev": true,
+      "requires": {
+        "iced-error": "0.0.12",
+        "iced-lock": "1.1.0",
+        "iced-runtime": "1.0.3",
+        "more-entropy": "0.0.7",
+        "progress": "1.1.8"
       }
     },
     "tunnel-agent": {
@@ -538,7 +735,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -546,6 +743,12 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
+    },
+    "uint64be": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uint64be/-/uint64be-1.0.1.tgz",
+      "integrity": "sha1-H3FUIC8qG4rzU4cd2mUb80zpPpU=",
+      "dev": true
     },
     "uuid": {
       "version": "3.2.1",
@@ -557,9 +760,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   },
   "devDependencies": {
     "async": "^2.6.0",
-    "promptly": "^2.2.0"
+    "bs58": "^4.0.1",
+    "kbpgp": "^2.0.77",
+    "promptly": "^2.2.0",
+    "request-promise": "^4.2.2"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/specification.md
+++ b/specification.md
@@ -142,7 +142,7 @@ and verifying against that. By only sending a hash of the public key the wallet 
 
 ### Key Distribution
 The JSON payment protocol provider will make keys available via the route:
-* <paymentRequestDomain>/signingKeys/paymentProtocol.json
+* [paymentRequestDomain]/signingKeys/paymentProtocol.json
 
 This route will serve a JSON payload which conforms to the format:
 
@@ -177,7 +177,7 @@ An example of this fully completed:
 
 ### Key Signature Distribution
 The JSON payment protocol provider will distribute PGP signatures of the distributed keys available via:
-* <paymentRequestDomain>/signatures/<sha256HashOfKeyPayload>.json
+* [paymentRequestDomain]/signatures/[sha256HashOfKeyPayload].json
 
 The SHA256 should be performed on the raw body of the keys sent down by the server.
 


### PR DESCRIPTION
Fixes docs where we had arrow brackets around variables which caused markdown to hide them.
Adds a new example util for fetching and verifying the keySet against published PGP keys.